### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   version-checker:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel previous runs


### PR DESCRIPTION
Potential fix for [https://github.com/yoonghan/walcron-microfrontend-shared/security/code-scanning/1](https://github.com/yoonghan/walcron-microfrontend-shared/security/code-scanning/1)

To fix the problem, add a `permissions` block to the `version-checker` job specifying the least privilege required. Since this job only checks versions and does not need to write to the repository or interact with pull requests, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` under the `version-checker` job, directly above the `runs-on` line (line 8). No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
